### PR TITLE
Bruker custom headere i kall mot bakveientilarbeid og min-side-proxy

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - "main"
-      - "ghcr"
+      - "allow-headere"
 env:
   "IMAGE": "ghcr.io/${{ github.repository }}/aia:${{ github.sha }}"
 jobs:

--- a/src/ducks/api.ts
+++ b/src/ducks/api.ts
@@ -1,5 +1,5 @@
 import { contextpathDittNav, erMikrofrontend } from "../utils/app-state-utils";
-// import { nanoid } from "nanoid";
+import { nanoid } from "nanoid";
 import { bakveienTilArbeidUrl, minSideProxyUrl } from "../url";
 
 export enum STATUS {
@@ -13,22 +13,21 @@ export enum STATUS {
 export interface DataElement {
   status: STATUS;
 }
-/*
+
 const getCookie = (name: string) => {
   const re = new RegExp(`${name}=([^;]+)`);
   const match = re.exec(document.cookie);
   return match !== null ? match[1] : "";
 };
-*/
 
 export const requestConfig = (): RequestInit => {
   return {
-    credentials: "include",
+    credentials: "same-origin",
     headers: {
       "Content-Type": "application/json",
-      //  NAV_CSRF_PROTECTION: getCookie("NAV_CSRF_PROTECTION"),
-      //  "NAV-Consumer-Id": "veientilarbeid",
-      //  "NAV-Call-Id": nanoid(),
+      NAV_CSRF_PROTECTION: getCookie("NAV_CSRF_PROTECTION"),
+      "NAV-Consumer-Id": "veientilarbeid",
+      "NAV-Call-Id": nanoid(),
     },
   };
 };

--- a/src/url.js
+++ b/src/url.js
@@ -21,8 +21,8 @@ const BAKVEIENTILARBEID_URL = {
 
 const MIN_SIDE_PROXY_URL = {
   local: "http://localhost:3000/tms-min-side-proxy",
-  development: "https://person.dev.nav.no/tms-min-side-proxy",
-  production: "https://person.intern.nav.no/tms-min-side-proxy",
+  development: "https://www.dev.nav.no/tms-min-side-proxy",
+  production: "https://www.intern.nav.no/tms-min-side-proxy",
 };
 
 const MINE_DAGPENGER_URL = {

--- a/src/url.js
+++ b/src/url.js
@@ -15,7 +15,7 @@ const getEnvironment = () => {
 
 const BAKVEIENTILARBEID_URL = {
   local: 'http://localhost:3000/bakveientilarbeid',
-  development: 'https://arbeid.dev.nav.no/bakveientilarbeid',
+  development: 'https://www.dev.nav.no/bakveientilarbeid',
   production: 'https://www.nav.no/bakveientilarbeid',
 };
 


### PR DESCRIPTION
Når man bruker `credendials: include` i kall fra AiA så må man whiteliste headere som ikke er cors-whitelistet i min-side-proxy. Dette unngår man hvis man setter `credentials: same-site` og ligger på samme origin. Bakveientilarbeid og min-side-proxy har derfor byttet ingress til å bruke www.intern.navn.no og www.dev.nav.no, slik at det blir mulig å bruke `NAV-* `headerne.